### PR TITLE
Fix duplicate HTML structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,64 +1,31 @@
 <!DOCTYPE html>
-<html >
+<html>
 <head>
   <meta charset="UTF-8">
   <title>Splash page</title>
-  
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.min.css">
-
   <link rel='stylesheet prefetch' href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700'>
-
-      <link rel="stylesheet" href="css/style.css">
-
-  
+  <link rel="stylesheet" href="css/style.css">
 </head>
-
-<body>
-  <!DOCTYPE html>
-<html >
-<head>
-  <meta charset="UTF-8">
-  <title>Splash page</title>
-  
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.min.css">
-
-  <link rel='stylesheet prefetch' href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700'>
-
-      <link rel="stylesheet" href="css/style.css">
-
-  
-</head>
-
 <body>
   <div class="splash">
-  <div class="splash_logo">
-    PIX
+    <div class="splash_logo">PIX</div>
+    <div class="splash_svg">
+      <svg width="100%" height="100%">
+        <rect width="100%" height="100%" />
+      </svg>
+    </div>
+    <div class="splash_minimize">
+      <svg width="100%" height="100%">
+        <rect width="100%" height="100%" />
+      </svg>
+    </div>
   </div>
-  <div class="splash_svg">
-    <svg width="100%" height="100%">
-      <rect width="100%" height="100%" >
-	  </svg>
+  <div class="text">
+    <img src="seedling_1f331.png" alt="Sprout">
+    <h1>Hetty...</h1>
+    <p>And her </br>numerous</br>attendants</p>
   </div>
-  <div class="splash_minimize">
-    <svg width="100%" height="100%">
-      <rect width="100%" height="100%" >
-	  </svg>
-  </div>
-</div>
-<div class="text">
-	<img src="seedling_1f331.png" alt="Sprout">
-	<h1>Hetty...</h1>
-	<p>And her </br>numerous</br>attendants</p>
-
-
-</div>
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0/jquery.min.js'></script>
-
-  
-</body>
-</html>
-  <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0/jquery.min.js'></script>
-
-  
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rewrite `index.html` with a single html/body structure
- keep script tag within the body
- confirm file parses with Python's HTML parser

## Testing
- `python3 - <<'PY'
from html.parser import HTMLParser
class Parser(HTMLParser):
    def error(self, message):
        print('Error:', message)

with open('index.html') as f:
    Parser().feed(f.read())
print('Parsing done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684985bd22f08329b9d1e6e8b3bbd6fd