### PR TITLE
Add mobile meta and interactive splash

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -36,11 +36,10 @@ body {
   animation: type2 .5s steps(60, end) 3.7s;
 }
 .text button {
-  border: 0;
+  border: 1px solid #FFA500;
   opacity: 0;
   background: #191919;
   color: #FFA500;
-  border: 1px solid #191919;
   letter-spacing: 2px;
   padding: .5rem 2.5rem;
   font-size: 12px;
@@ -60,7 +59,7 @@ body {
 .text button:hover {
   background: #FFA500;
   color: #191919;
-  border: 1px solid #191919;
+  border: 1px solid #FFA500;
 }
 
 .splash {

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
 <head>
   <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Splash page</title>
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/meyer-reset/2.0/reset.min.css">
   <link rel='stylesheet prefetch' href='https://fonts.googleapis.com/css?family=Open+Sans:400,300,600,700'>
@@ -25,7 +26,9 @@
     <img src="seedling_1f331.png" alt="Sprout">
     <h1>Hetty...</h1>
     <p>And her </br>numerous</br>attendants</p>
+    <button onclick="location.href='Twitch/index.html'">Enter</button>
   </div>
   <script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.0.0/jquery.min.js'></script>
+  <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,12 @@
+document.addEventListener('DOMContentLoaded', function () {
+  var splash = document.querySelector('.splash');
+  var enterButton = document.querySelector('.text button');
+
+  if (enterButton) {
+    enterButton.addEventListener('click', function () {
+      if (splash) {
+        splash.style.display = 'none';
+      }
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- improve mobile layout with viewport meta tag
- add Enter button in splash text
- tweak `.text button` styling so it stays visible
- load new script to hide the splash when the button is clicked

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6859231d4a248329ad32f985237d3207